### PR TITLE
导入词典时，累加并重新计算词频。

### DIFF
--- a/src/class/Jieba.php
+++ b/src/class/Jieba.php
@@ -156,7 +156,7 @@ class Jieba
             $freq = $explode_line[1];
             $tag = $explode_line[2];
             $freq = (float) $freq;
-            if ( ! isset(self::$original_freq[$word])) {
+            if (!isset(self::$original_freq[$word])) {
                 self::$original_freq[$word] = 0;
             }
             self::$original_freq[$word] += $freq;
@@ -194,7 +194,7 @@ class Jieba
             $tag = $explode_line[2];
             $freq = (float) $freq;
             self::$total += $freq;
-            if ( ! isset(self::$original_freq[$word])) {
+            if (!isset(self::$original_freq[$word])) {
                 self::$original_freq[$word] = 0;
             }
             self::$original_freq[$word] += $freq;

--- a/src/class/Jieba.php
+++ b/src/class/Jieba.php
@@ -156,10 +156,10 @@ class Jieba
             $freq = $explode_line[1];
             $tag = $explode_line[2];
             $freq = (float) $freq;
-            if (!isset(self::$original_freq[$word])) {
-                self::$original_freq[$word] = 0;
+            if (isset(self::$original_freq[$word])) {
+                self::$total -= self::$original_freq[$word];
             }
-            self::$original_freq[$word] += $freq;
+            self::$original_freq[$word] = $freq;
             self::$total += $freq;
             //$l = mb_strlen($word, 'UTF-8');
             //$word_c = array();
@@ -193,11 +193,11 @@ class Jieba
             $freq = $explode_line[1];
             $tag = $explode_line[2];
             $freq = (float) $freq;
-            self::$total += $freq;
-            if (!isset(self::$original_freq[$word])) {
-                self::$original_freq[$word] = 0;
+            if (isset(self::$original_freq[$word])) {
+                self::$total -= self::$original_freq[$word];
             }
-            self::$original_freq[$word] += $freq;
+            self::$original_freq[$word] = $freq;
+            self::$total += $freq;
             $l = mb_strlen($word, 'UTF-8');
             $word_c = array();
             for ($i=0; $i<$l; $i++) {


### PR DESCRIPTION
1 既然 `self::$total `是累加得到，那么单个词的词频也应该累加，或者两者都应该用覆盖处理，我在这里实现了前者,如果是需要后者，我会再改:)

2 在导入完成后，需要全部重新计算一遍，因为`self::$total `已经发生变化。