### PR TITLE
添加日语朝鲜语不过滤选项

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,216 @@ array(7) {
 }
 ```
 
+功能 5)：切換成繁體字典
+==============
+
+代碼示例 (Tutorial)
+
+```php
+ini_set('memory_limit', '1024M');
+
+require_once dirname(dirname(__FILE__))."/vendor/multi-array/MultiArray.php";
+require_once dirname(dirname(__FILE__))."/vendor/multi-array/Factory/MultiArrayFactory.php";
+require_once dirname(dirname(__FILE__))."/class/Jieba.php";
+require_once dirname(dirname(__FILE__))."/class/Finalseg.php";
+use Fukuball\Jieba\Jieba;
+use Fukuball\Jieba\Finalseg;
+Jieba::init(array('mode'=>'default','dict'=>'big'));
+Finalseg::init();
+
+$seg_list = Jieba::cut("怜香惜玉也得要看对象啊！");
+var_dump($seg_list);
+
+$seg_list = Jieba::cut("憐香惜玉也得要看對象啊！");
+var_dump($seg_list);
+```
+
+Output:
+
+```php
+array(7) {
+  [0]=>
+  string(12) "怜香惜玉"
+  [1]=>
+  string(3) "也"
+  [2]=>
+  string(3) "得"
+  [3]=>
+  string(3) "要"
+  [4]=>
+  string(3) "看"
+  [5]=>
+  string(6) "对象"
+  [6]=>
+  string(3) "啊"
+}
+array(7) {
+  [0]=>
+  string(12) "憐香惜玉"
+  [1]=>
+  string(3) "也"
+  [2]=>
+  string(3) "得"
+  [3]=>
+  string(3) "要"
+  [4]=>
+  string(3) "看"
+  [5]=>
+  string(6) "對象"
+  [6]=>
+  string(3) "啊"
+}
+```
+
+功能 6)：保留日语或者朝鲜语原文不进行过滤
+==============
+
+代碼示例 (Tutorial)
+
+```php
+ini_set('memory_limit', '1024M');
+
+require_once dirname(dirname(__FILE__))."/vendor/multi-array/MultiArray.php";
+require_once dirname(dirname(__FILE__))."/vendor/multi-array/Factory/MultiArrayFactory.php";
+require_once dirname(dirname(__FILE__))."/class/Jieba.php";
+require_once dirname(dirname(__FILE__))."/class/Finalseg.php";
+use Fukuball\Jieba\Jieba;
+use Fukuball\Jieba\Finalseg;
+Jieba::init(array('cjk'=>'all'));
+Finalseg::init();
+
+$seg_list = Jieba::cut("한국어 또는 조선말은 제주특별자치도를 제외한 한반도 및 그 부속 도서와 한민족 거주 지역에서 쓰이는 언어로");
+var_dump($seg_list);
+
+$seg_list = Jieba::cut("日本語は、主に日本国内や日本人同士の間で使われている言語である。");
+var_dump($seg_list);
+
+$seg_list = Jieba::cut("日本語は、主に日本国内や日本人同士の間で使われている言語である。");
+var_dump($seg_list);
+
+// 加载日语词库可以对日语进行简单的分词
+Jieba::loadUserDict("/path/to/your/japanese/dict.txt");
+$seg_list = Jieba::cut("日本語は、主に日本国内や日本人同士の間で使われている言語である。");
+var_dump($seg_list);
+```
+
+Output:
+
+```php
+array(15) {
+  [0]=>
+  string(9) "한국어"
+  [1]=>
+  string(6) "또는"
+  [2]=>
+  string(12) "조선말은"
+  [3]=>
+  string(24) "제주특별자치도를"
+  [4]=>
+  string(9) "제외한"
+  [5]=>
+  string(9) "한반도"
+  [6]=>
+  string(3) "및"
+  [7]=>
+  string(3) "그"
+  [8]=>
+  string(6) "부속"
+  [9]=>
+  string(9) "도서와"
+  [10]=>
+  string(9) "한민족"
+  [11]=>
+  string(6) "거주"
+  [12]=>
+  string(12) "지역에서"
+  [13]=>
+  string(9) "쓰이는"
+  [14]=>
+  string(9) "언어로"
+}
+array(21) {
+  [0]=>
+  string(6) "日本"
+  [1]=>
+  string(3) "語"
+  [2]=>
+  string(3) "は"
+  [3]=>
+  string(3) "主"
+  [4]=>
+  string(3) "に"
+  [5]=>
+  string(6) "日本"
+  [6]=>
+  string(6) "国内"
+  [7]=>
+  string(3) "や"
+  [8]=>
+  string(6) "日本"
+  [9]=>
+  string(3) "人"
+  [10]=>
+  string(6) "同士"
+  [11]=>
+  string(3) "の"
+  [12]=>
+  string(3) "間"
+  [13]=>
+  string(3) "で"
+  [14]=>
+  string(3) "使"
+  [15]=>
+  string(3) "わ"
+  [16]=>
+  string(6) "れて"
+  [17]=>
+  string(6) "いる"
+  [18]=>
+  string(6) "言語"
+  [19]=>
+  string(3) "で"
+  [20]=>
+  string(6) "ある"
+}
+array(17) {
+  [0]=>
+  string(9) "日本語"
+  [1]=>
+  string(3) "は"
+  [2]=>
+  string(6) "主に"
+  [3]=>
+  string(9) "日本国"
+  [4]=>
+  string(3) "内"
+  [5]=>
+  string(3) "や"
+  [6]=>
+  string(9) "日本人"
+  [7]=>
+  string(6) "同士"
+  [8]=>
+  string(3) "の"
+  [9]=>
+  string(3) "間"
+  [10]=>
+  string(3) "で"
+  [11]=>
+  string(3) "使"
+  [12]=>
+  string(3) "わ"
+  [13]=>
+  string(6) "れて"
+  [14]=>
+  string(6) "いる"
+  [15]=>
+  string(6) "言語"
+  [16]=>
+  string(9) "である"
+}
+```
+
 常見問題
 ========
 1) 模型的數據是如何生成的？ https://github.com/fxsjy/jieba/issues/7
@@ -1041,6 +1251,155 @@ array(7) {
   string(6) "對象"
   [6]=>
   string(3) "啊"
+}
+```
+
+Function 6)：Keeping Japanese or Korean original text
+==============
+
+Example (Tutorial)
+
+```php
+ini_set('memory_limit', '1024M');
+
+require_once dirname(dirname(__FILE__))."/vendor/multi-array/MultiArray.php";
+require_once dirname(dirname(__FILE__))."/vendor/multi-array/Factory/MultiArrayFactory.php";
+require_once dirname(dirname(__FILE__))."/class/Jieba.php";
+require_once dirname(dirname(__FILE__))."/class/Finalseg.php";
+use Fukuball\Jieba\Jieba;
+use Fukuball\Jieba\Finalseg;
+Jieba::init(array('cjk'=>'all'));
+Finalseg::init();
+
+$seg_list = Jieba::cut("한국어 또는 조선말은 제주특별자치도를 제외한 한반도 및 그 부속 도서와 한민족 거주 지역에서 쓰이는 언어로");
+var_dump($seg_list);
+
+$seg_list = Jieba::cut("日本語は、主に日本国内や日本人同士の間で使われている言語である。");
+var_dump($seg_list);
+
+$seg_list = Jieba::cut("日本語は、主に日本国内や日本人同士の間で使われている言語である。");
+var_dump($seg_list);
+
+// Loading custom Japanese dictionary can do a simple word segmentation
+Jieba::loadUserDict("/path/to/your/japanese/dict.txt");
+$seg_list = Jieba::cut("日本語は、主に日本国内や日本人同士の間で使われている言語である。");
+var_dump($seg_list);
+```
+
+Output:
+
+```php
+array(15) {
+  [0]=>
+  string(9) "한국어"
+  [1]=>
+  string(6) "또는"
+  [2]=>
+  string(12) "조선말은"
+  [3]=>
+  string(24) "제주특별자치도를"
+  [4]=>
+  string(9) "제외한"
+  [5]=>
+  string(9) "한반도"
+  [6]=>
+  string(3) "및"
+  [7]=>
+  string(3) "그"
+  [8]=>
+  string(6) "부속"
+  [9]=>
+  string(9) "도서와"
+  [10]=>
+  string(9) "한민족"
+  [11]=>
+  string(6) "거주"
+  [12]=>
+  string(12) "지역에서"
+  [13]=>
+  string(9) "쓰이는"
+  [14]=>
+  string(9) "언어로"
+}
+array(21) {
+  [0]=>
+  string(6) "日本"
+  [1]=>
+  string(3) "語"
+  [2]=>
+  string(3) "は"
+  [3]=>
+  string(3) "主"
+  [4]=>
+  string(3) "に"
+  [5]=>
+  string(6) "日本"
+  [6]=>
+  string(6) "国内"
+  [7]=>
+  string(3) "や"
+  [8]=>
+  string(6) "日本"
+  [9]=>
+  string(3) "人"
+  [10]=>
+  string(6) "同士"
+  [11]=>
+  string(3) "の"
+  [12]=>
+  string(3) "間"
+  [13]=>
+  string(3) "で"
+  [14]=>
+  string(3) "使"
+  [15]=>
+  string(3) "わ"
+  [16]=>
+  string(6) "れて"
+  [17]=>
+  string(6) "いる"
+  [18]=>
+  string(6) "言語"
+  [19]=>
+  string(3) "で"
+  [20]=>
+  string(6) "ある"
+}
+array(17) {
+  [0]=>
+  string(9) "日本語"
+  [1]=>
+  string(3) "は"
+  [2]=>
+  string(6) "主に"
+  [3]=>
+  string(9) "日本国"
+  [4]=>
+  string(3) "内"
+  [5]=>
+  string(3) "や"
+  [6]=>
+  string(9) "日本人"
+  [7]=>
+  string(6) "同士"
+  [8]=>
+  string(3) "の"
+  [9]=>
+  string(3) "間"
+  [10]=>
+  string(3) "で"
+  [11]=>
+  string(3) "使"
+  [12]=>
+  string(3) "わ"
+  [13]=>
+  string(6) "れて"
+  [14]=>
+  string(6) "いる"
+  [15]=>
+  string(6) "言語"
+  [16]=>
+  string(9) "である"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ require_once "/path/to/your/class/JiebaAnalyse.php";
 use Fukuball\Jieba\Jieba;
 use Fukuball\Jieba\Finalseg;
 use Fukuball\Jieba\JiebaAnalyse;
-Jieba::init(array('mode'=>'test','dict'=>'samll'));
+Jieba::init(array('mode'=>'test','dict'=>'small'));
 Finalseg::init();
 JiebaAnalyse::init();
 
@@ -623,9 +623,6 @@ var_dump($seg_list);
 $seg_list = Jieba::cut("日本語は、主に日本国内や日本人同士の間で使われている言語である。");
 var_dump($seg_list);
 
-$seg_list = Jieba::cut("日本語は、主に日本国内や日本人同士の間で使われている言語である。");
-var_dump($seg_list);
-
 // 加载日语词库可以对日语进行简单的分词
 Jieba::loadUserDict("/path/to/your/japanese/dict.txt");
 $seg_list = Jieba::cut("日本語は、主に日本国内や日本人同士の間で使われている言語である。");
@@ -977,7 +974,7 @@ require_once "/path/to/your/class/JiebaAnalyse.php";
 use Fukuball\Jieba\Jieba;
 use Fukuball\Jieba\Finalseg;
 use Fukuball\Jieba\JiebaAnalyse;
-Jieba::init(array('mode'=>'test','dict'=>'samll'));
+Jieba::init(array('mode'=>'test','dict'=>'small'));
 Finalseg::init();
 JiebaAnalyse::init();
 
@@ -1272,9 +1269,6 @@ Jieba::init(array('cjk'=>'all'));
 Finalseg::init();
 
 $seg_list = Jieba::cut("한국어 또는 조선말은 제주특별자치도를 제외한 한반도 및 그 부속 도서와 한민족 거주 지역에서 쓰이는 언어로");
-var_dump($seg_list);
-
-$seg_list = Jieba::cut("日本語は、主に日本国内や日本人同士の間で使われている言語である。");
 var_dump($seg_list);
 
 $seg_list = Jieba::cut("日本語は、主に日本国内や日本人同士の間で使われている言語である。");

--- a/src/class/Finalseg.php
+++ b/src/class/Finalseg.php
@@ -233,10 +233,10 @@ class Finalseg
 
         $seg_list = array();
 
-        $re_han_pattern = '([\x{4E00}-\x{9FA5}]+)';
+        $re_cjk_pattern = '([\x{3040}-\x{309F}]+)|([\x{30A0}-\x{30FF}]+)|([\x{4E00}-\x{9FA5}]+)|([\x{AC00}-\x{D7AF}]+)';
         $re_skip_pattern = '([a-zA-Z0-9+#\r\n]+)';
         preg_match_all(
-            '/('.$re_han_pattern.'|'.$re_skip_pattern.')/u',
+            '/('.$re_cjk_pattern.'|'.$re_skip_pattern.')/u',
             $sentence,
             $matches,
             PREG_PATTERN_ORDER
@@ -245,7 +245,7 @@ class Finalseg
 
         foreach ($blocks as $blk) {
 
-            if (preg_match('/'.$re_han_pattern.'/u', $blk)) {
+            if (preg_match('/'.$re_cjk_pattern.'/u', $blk)) {
 
                 $words = self::__cut($blk);
 

--- a/src/class/Jieba.php
+++ b/src/class/Jieba.php
@@ -37,7 +37,8 @@ class Jieba
     public static $min_freq = 0.0;
     public static $route = array();
     public static $dictname;
-    public static $user_dictname=array();
+    public static $user_dictname = array();
+    public static $cjk_all = false;
 
     /**
      * Static method init
@@ -50,7 +51,8 @@ class Jieba
     {
         $defaults = array(
             'mode'=>'default',
-            'dict'=>'normal'
+            'dict'=>'normal',
+            'cjk'=>'chinese'
         );
 
         $options = array_merge($defaults, $options);
@@ -68,6 +70,12 @@ class Jieba
         } else {
             $f_name = "dict.txt";
             self::$dictname="dict.txt";
+        }
+
+        if ($options['cjk']=='all') {
+            self::$cjk_all = true;
+        } else {
+            self::$cjk_all = false;
         }
 
         $t1 = microtime(true);
@@ -402,9 +410,20 @@ class Jieba
         $seg_list = array();
 
         $re_han_pattern = '([\x{4E00}-\x{9FA5}]+)';
-        $re_skip_pattern = '([a-zA-Z0-9+#\r\n]+)';
+        $re_kanjikana_pattern = '([\x{3040}-\x{309F}\x{4E00}-\x{9FA5}]+)';
+        $re_katakana_pattern = '([\x{30A0}-\x{30FF}]+)';
+        $re_hangul_pattern = '([\x{AC00}-\x{D7AF}]+)';
+        $re_ascii_pattern = '([a-zA-Z0-9+#\r\n]+)';
+
+        if (self::$cjk_all)
+            $filter_pattern = $re_kanjikana_pattern.
+                            '|'.$re_katakana_pattern.
+                            '|'.$re_hangul_pattern;
+        else
+            $filter_pattern = $re_han_pattern;
+
         preg_match_all(
-            '/('.$re_han_pattern.'|'.$re_skip_pattern.')/u',
+            '/('.$filter_pattern.'|'.$re_ascii_pattern.')/u',
             $sentence,
             $matches,
             PREG_PATTERN_ORDER
@@ -412,7 +431,12 @@ class Jieba
         $blocks = $matches[0];
 
         foreach ($blocks as $blk) {
-            if (preg_match('/'.$re_han_pattern.'/u', $blk)) {
+            if (self::$cjk_all) // skip korean
+                $filter_pattern = $re_kanjikana_pattern.'|'.$re_katakana_pattern;
+            else
+                $filter_pattern = $re_han_pattern;
+
+            if (preg_match('/'.$filter_pattern.'/u', $blk)) {
                 if ($cut_all) {
                     $words = Jieba::__cutAll($blk);
                 } else {

--- a/src/class/Jieba.php
+++ b/src/class/Jieba.php
@@ -198,8 +198,8 @@ class Jieba
         while (($line = fgets($content)) !== false) {
             $explode_line = explode(" ", trim($line));
             $word = $explode_line[0];
-            $freq = $explode_line[1];
-            $tag = $explode_line[2];
+            $freq = isset($explode_line[1]) ? $explode_line[1] : 1;
+            $tag = isset($explode_line[2]) ? $explode_line[2] : null;
             $freq = (float) $freq;
             if (isset(self::$original_freq[$word])) {
                 self::$total -= self::$original_freq[$word];


### PR DESCRIPTION
- 因为 #24 添加日语朝鲜语不过滤选项
- 更改用户词典词频与词性为可选，避免只有纯词组时加载用户词典报错
- 修正 Readme 文件中 ```samll``` 错字