### PR TITLE
给DAG处理增加缓存，提升性能

### DIFF
--- a/src/class/Jieba.php
+++ b/src/class/Jieba.php
@@ -80,6 +80,7 @@ class Jieba
         }
 
         $t1 = microtime(true);
+        self::$dag_cache = array();
         self::$trie = Jieba::genTrie(dirname(dirname(__FILE__))."/dict/".$f_name);
         self::__calcFreq();
 
@@ -218,6 +219,7 @@ class Jieba
         }
         fclose($content);
         self::__calcFreq();
+        self::$dag_cache = array();
 
         return self::$trie;
     }// end function loadUserDict
@@ -434,7 +436,6 @@ class Jieba
 
         $options = array_merge($defaults, $options);
 
-        self::$dag_cache = array();
         $seg_list = array();
 
         $re_han_pattern = '([\x{4E00}-\x{9FA5}]+)';


### PR DESCRIPTION
尝试从以下两个方面提高性能。
1 `self::$trie`命中的词组，无需再做一次end相关的比较。
2 `self::$trie`未命中的词组，若多次出现，则第二次开始，无需再去调用`MultiArray::get`并最终用`MultiArray::getValue`进行递归遍历。
因为是跟self::$trie相关，所以在self::$trie作修改的时候需要清除缓存。

我用如下代码在浏览器中进行测试，跟之前对比，大概能有百分之二十左右的提升。像"是否和"一词在lyric.txt.中出现了8次，对它的处理就会比之前更快。


```
$top_k = 10;
$content = file_get_contents(dirname(__FILE__)."/../src/dict/lyric.txt", "r");
$t1 = microtime(true);
for ($i = 0; $i < 100; $i++) {
    Jieba::$dag_cache = array();
    $tags = JiebaAnalyse::extractTags($content, $top_k);
}
$t2 = microtime(true);
echo ($t2 - $t1)."<br>\n";
```

不知对 #27  会不会有所帮助。