### PR TITLE
extractTags方法选项设置allowPOS后可能异常

### DIFF
--- a/src/class/JiebaAnalyse.php
+++ b/src/class/JiebaAnalyse.php
@@ -122,6 +122,7 @@ class JiebaAnalyse
         if (isset($options['allowPOS'])) {
             $wordsPos = Posseg::cut($content);
 
+            $words = array();
             foreach ($wordsPos as $key => $word) {
                 if (in_array($word['tag'], $options['allowPOS'])) {
                     $words[] = $word['word'];

--- a/src/class/JiebaAnalyse.php
+++ b/src/class/JiebaAnalyse.php
@@ -119,7 +119,7 @@ class JiebaAnalyse
 
         $tags = array();
 
-        if (isset($options['allowPOS'])) {
+        if (isset($options['allowPOS']) && is_array($options['allowPOS']) && !empty($options['allowPOS'])) {
             $wordsPos = Posseg::cut($content);
 
             $words = array();


### PR DESCRIPTION
未预先设置$words变量，导致程序异常。

```
foreach ($wordsPos as $key => $word) {
    if (in_array($word['tag'], $options['allowPOS'])) {
        $words[] = $word['word'];
    }
}
```



