### PR TITLE
Fix array_merge() warning by casting options to array

### DIFF
--- a/src/class/JiebaAnalyse.php
+++ b/src/class/JiebaAnalyse.php
@@ -53,7 +53,7 @@ class JiebaAnalyse
             'dict'=>'normal'
         );
 
-        $options = array_merge($defaults, $options);
+        $options = array_merge($defaults, (array)$options);
 
         if ($options['dict']=='big') {
             $f_name = "idf.big.txt";
@@ -115,7 +115,7 @@ class JiebaAnalyse
             'mode'=>'default'
         );
 
-        $options = array_merge($defaults, $options);
+        $options = array_merge($defaults, (array)$options);
 
         $tags = array();
 


### PR DESCRIPTION
This PR fixes the PHP warning that occurs when non-array values are passed to methods that use array_merge() with options parameters.

**Changes:**
- Cast $options parameter to array in JiebaAnalyse::init() and JiebaAnalyse::extractTags() methods
- Resolves PHP 7  warning when non-array values are passed as options
- Maintains backward compatibility

**Fixes:** #80

Generated with [Claude Code](https://claude.ai/code)