### PR TITLE
新增 GitHub Actions test coverage report 功能

### DIFF
--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -41,8 +41,21 @@ jobs:
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress
 
-      - name: Run test suite
-        run: vendor/bin/phpunit --configuration phpunit.xml --colors --coverage-text
+      - name: Create build directory
+        run: mkdir -p build/logs
+
+      - name: Run test suite with coverage
+        run: vendor/bin/phpunit --configuration phpunit.xml --colors --coverage-text --coverage-clover=build/logs/clover.xml
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          file: ./build/logs/clover.xml
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Run code style check
         run: vendor/bin/phpcs --standard=PSR2 --extensions=php --ignore="*/test/*" ./src/class

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -45,7 +45,7 @@ jobs:
         run: mkdir -p build/logs
 
       - name: Run test suite with coverage
-        run: vendor/bin/phpunit --configuration phpunit.xml --colors --coverage-text --coverage-clover=build/logs/clover.xml
+        run: vendor/bin/phpunit --configuration phpunit.xml --colors --coverage-text
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # [jieba-php](http://www.fukuball.com/jieba-php/)
 
 [![Made with Love](https://img.shields.io/badge/made%20with-%e2%9d%a4-ff69b4.svg)](http://www.fukuball.com)
+[![codecov](https://codecov.io/gh/fukuball/jieba-php/branch/master/graph/badge.svg)](https://codecov.io/gh/fukuball/jieba-php)
 
 "結巴"中文分詞：做最好的 PHP 中文分詞、中文斷詞組件，原始版本翻譯自[fxsjy/jieba](https://github.com/fxsjy/jieba)，目前已經為一個獨立分支，請有興趣的開發者一起加入開發！若想使用 Python 版本請前往 [fxsjy/jieba](https://github.com/fxsjy/jieba)
 


### PR DESCRIPTION
## Summary
- 修改 GitHub Actions workflow 來產生 clover coverage report
- 新增 Codecov 上傳功能自動追蹤測試覆蓋率
- 在 README 新增 coverage badge 顯示即時測試覆蓋率狀態

## Test plan
- [x] 修改 `.github/workflows/php-tests.yml` 加入 coverage 產生和上傳
- [x] 確保 `phpunit.xml` 已設定 clover report 輸出
- [x] 新增 README coverage badge
- [ ] 設定 GitHub repository secrets 中的 `CODECOV_TOKEN`
- [ ] 驗證 coverage report 在 Codecov 正常顯示

## 注意事項
需要在 GitHub repository 的 Settings > Secrets 中設定 `CODECOV_TOKEN`。
可到 [codecov.io](https://codecov.io) 註冊並連結 GitHub repository 取得 token。

🤖 Generated with [Claude Code](https://claude.ai/code)