### PR TITLE
Add preserve_punctuation option to control punctuation in segmentation

### DIFF
--- a/src/class/Jieba.php
+++ b/src/class/Jieba.php
@@ -562,7 +562,13 @@ class Jieba
     {
         self::requireInitialization();
 
-        $seg_list = self::cut($sentence, false, array("HMM" => $options["HMM"]));
+        $defaults = array(
+            'preserve_punctuation' => true
+        );
+
+        $options = array_merge($defaults, $options);
+
+        $seg_list = self::cut($sentence, false, array("HMM" => $options["HMM"], "preserve_punctuation" => $options["preserve_punctuation"]));
         $tokenize_list = [];
         $start = 0;
         $end = 0;
@@ -856,7 +862,8 @@ class Jieba
         self::requireInitialization();
 
         $defaults = array(
-            'mode' => 'default'
+            'mode' => 'default',
+            'preserve_punctuation' => true
         );
 
         $options = array_merge($defaults, $options);
@@ -937,7 +944,9 @@ class Jieba
                     }
                 }
             } elseif (preg_match('/' . $re_punctuation_pattern . '/u', $blk)) {
-                $seg_list[] = $blk;
+                if ($options['preserve_punctuation']) {
+                    $seg_list[] = $blk;
+                }
             } // end else (preg_match('/'.$re_han_pattern.'/u', $blk))
         } // end foreach ($blocks as $blk)
 
@@ -957,14 +966,15 @@ class Jieba
         self::requireInitialization();
 
         $defaults = array(
-            'mode' => 'default'
+            'mode' => 'default',
+            'preserve_punctuation' => true
         );
 
         $options = array_merge($defaults, $options);
 
         $seg_list = array();
 
-        $cut_seg_list = Jieba::cut($sentence, false, array("HMM" => $options["HMM"]));
+        $cut_seg_list = Jieba::cut($sentence, false, array("HMM" => $options["HMM"], "preserve_punctuation" => $options["preserve_punctuation"]));
 
         foreach ($cut_seg_list as $w) {
             $len = mb_strlen($w, 'UTF-8');

--- a/test/JiebaTest.php
+++ b/test/JiebaTest.php
@@ -478,4 +478,68 @@ class JiebaTest extends TestCase
         $this->assertTrue(isset(Posseg::$word_tag['直接測試']));
         $this->assertEquals('direct_tag', Posseg::$word_tag['直接測試']);
     }
+
+    public function testPreservePunctuationOption()
+    {
+        Jieba::init();
+        
+        // Test sentence with punctuation
+        $sentence = "这是一个测试！有标点符号，对吧？";
+        
+        // Test with preserve_punctuation = true (default behavior)
+        $result_with_punct = Jieba::cut($sentence, false, array("preserve_punctuation" => true));
+        $this->assertContains("！", $result_with_punct);
+        $this->assertContains("，", $result_with_punct);
+        $this->assertContains("？", $result_with_punct);
+        
+        // Test with preserve_punctuation = false
+        $result_without_punct = Jieba::cut($sentence, false, array("preserve_punctuation" => false));
+        $this->assertNotContains("！", $result_without_punct);
+        $this->assertNotContains("，", $result_without_punct);
+        $this->assertNotContains("？", $result_without_punct);
+        
+        // Test default behavior (should preserve punctuation)
+        $result_default = Jieba::cut($sentence);
+        $this->assertContains("！", $result_default);
+        $this->assertContains("，", $result_default);
+        $this->assertContains("？", $result_default);
+    }
+
+    public function testPreservePunctuationInCutForSearch()
+    {
+        Jieba::init();
+        
+        // Test sentence with punctuation
+        $sentence = "小明硕士毕业于中国科学院计算所，后在日本京都大学深造。";
+        
+        // Test with preserve_punctuation = true
+        $result_with_punct = Jieba::cutForSearch($sentence, array("preserve_punctuation" => true));
+        $this->assertContains("，", $result_with_punct);
+        $this->assertContains("。", $result_with_punct);
+        
+        // Test with preserve_punctuation = false
+        $result_without_punct = Jieba::cutForSearch($sentence, array("preserve_punctuation" => false));
+        $this->assertNotContains("，", $result_without_punct);
+        $this->assertNotContains("。", $result_without_punct);
+    }
+
+    public function testPreservePunctuationInTokenize()
+    {
+        Jieba::init();
+        
+        // Test sentence with punctuation
+        $sentence = "测试！标点符号。";
+        
+        // Test with preserve_punctuation = true
+        $result_with_punct = Jieba::tokenize($sentence, array("preserve_punctuation" => true));
+        $words_with_punct = array_column($result_with_punct, 'word');
+        $this->assertContains("！", $words_with_punct);
+        $this->assertContains("。", $words_with_punct);
+        
+        // Test with preserve_punctuation = false
+        $result_without_punct = Jieba::tokenize($sentence, array("preserve_punctuation" => false));
+        $words_without_punct = array_column($result_without_punct, 'word');
+        $this->assertNotContains("！", $words_without_punct);
+        $this->assertNotContains("。", $words_without_punct);
+    }
 }


### PR DESCRIPTION
This PR adds a new `preserve_punctuation` option to the Jieba segmentation methods that allows users to choose whether to preserve or exclude punctuation marks from segmentation results.

## Changes

- Added `preserve_punctuation` option to `cut()`, `cutForSearch()`, and `tokenize()` methods
- Default value is `true` to maintain backward compatibility
- When set to `false`, punctuation marks are excluded from segmentation results
- Added comprehensive tests to verify functionality

## Usage

```php
// Default behavior (preserves punctuation)
$result = Jieba::cut("这是测试！有标点符号，对吧？");

// Without punctuation
$result = Jieba::cut("这是测试！有标点符号，对吧？", false, ["preserve_punctuation" => false]);
```

Fixes #47

Generated with [Claude Code](https://claude.ai/code)